### PR TITLE
Adds shared access signature (SAS) support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,11 @@ branding:
   color: "green"
 inputs:
   connection_string:
-    description: "The connection string for the storage account"
-    required: true
+    description: "The connection string for the storage account. Used if value is set. Either connection_string or sas_token must be supplied"
+    required: false
+  sas_token:
+    description: "The shared access signature token for the storage account. Either connection_string or sas_token must be supplied"
+    required: false
   container_name:
     description: "The name of the storage account container these assets will be uploaded to"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   sas_token:
     description: "The shared access signature token for the storage account. Either connection_string or sas_token must be supplied"
     required: false
+  account_name:
+    description: "The name of the storage account. Required if sas_token is used"
+    required: false
   container_name:
     description: "The name of the storage account container these assets will be uploaded to"
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,11 +20,11 @@ elif ! [ -z "$INPUT_SAS_TOKEN" ]; then
   if ! [ -z "$INPUT_ACCOUNT_NAME" ]; then
     CONNECTION_METHOD="--sas-token $INPUT_SAS_TOKEN --account-name $INPUT_ACCOUNT_NAME"
   else
-    echo "account_name is required if using an sas-token. account_name is not set. Quitting."
+    echo "account_name is required if using a sas_token. account_name is not set. Quitting."
     exit 1
   fi
 else
-  echo "either connection-string or sas-token are required and neither is set. Quitting."
+  echo "either connection_string or sas_token are required and neither is set. Quitting."
   exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,12 +12,21 @@ if [ -z "$INPUT_CONTAINER_NAME" ]; then
   exit 1
 fi
 
-if [ -z "$INPUT_CONNECTION_STRING" ]; then
-  echo "storage account connection string is not set. Quitting."
+CONNECTION_METHOD=""
+
+if ! [ -z "$INPUT_CONNECTION_STRING" ]; then
+  CONNECTION_METHOD="--connection-string $INPUT_CONNECTION_STRING"
+elif ! [ -z "$INPUT_SAS_TOKEN" ]; then
+  CONNECTION_METHOD="--sas-token $INPUT_SAS_TOKEN --account-name jeft87m12yrdvja42zw0sp47"
+else
+  echo "either connection-string or sas-token are required and neither is set. Quitting."
   exit 1
 fi
 
-EXTRA_ARGS=${INPUT_EXTRA_ARGS:""}
+EXTRA_ARGS=""
+if [ -z "$INPUT_EXTRA_ARGS" ]; then
+  EXTRA_ARGS=${INPUT_EXTRA_ARGS}
+fi
 
 VERB="upload-batch"
 CONTAINER_NAME_FLAG="--destination"
@@ -25,4 +34,5 @@ if [ -z "$INPUT_SYNC" ]; then
   VERB="sync"
   CONTAINER_NAME_FLAG="--container"
 fi
-az storage blob ${VERB} --connection-string ${INPUT_CONNECTION_STRING} --source ${INPUT_SOURCE_DIR} ${CONTAINER_NAME_FLAG} ${INPUT_CONTAINER_NAME} ${EXTRA_ARGS}
+
+az storage blob ${VERB} ${CONNECTION_METHOD} --source ${INPUT_SOURCE_DIR} ${CONTAINER_NAME_FLAG} ${INPUT_CONTAINER_NAME} ${EXTRA_ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,12 @@ CONNECTION_METHOD=""
 if ! [ -z "$INPUT_CONNECTION_STRING" ]; then
   CONNECTION_METHOD="--connection-string $INPUT_CONNECTION_STRING"
 elif ! [ -z "$INPUT_SAS_TOKEN" ]; then
-  CONNECTION_METHOD="--sas-token $INPUT_SAS_TOKEN --account-name jeft87m12yrdvja42zw0sp47"
+  if ! [ -z "$INPUT_ACCOUNT_NAME" ]; then
+    CONNECTION_METHOD="--sas-token $INPUT_SAS_TOKEN --account-name $INPUT_ACCOUNT_NAME"
+  else
+    echo "account_name is required if using an sas-token. account_name is not set. Quitting."
+    exit 1
+  fi
 else
   echo "either connection-string or sas-token are required and neither is set. Quitting."
   exit 1


### PR DESCRIPTION
This adds support for using a Shared Access Signature in the azure blob storage upload/sync action.

New inputs

- sas_token: Token available from creating a shared access signature in the Azure Portal or output from terraform module
- account_name: Name of the storage account. Necessary for the az storage blob command to build the full URL

Modifies connection_string to be optional. Either the connection_string or the sas_token must be supplied, defaulting to connection_string if both are present. If sas_token is supplied, account_name becomes required.