### PR TITLE
allow cli version to be configurable at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-cli:2.33.1
+FROM python:latest
 
 LABEL "com.github.actions.name"="azure-blob-storage-upload"
 LABEL "com.github.actions.description"="Uploads assets to Azure Blob Storage"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Matthew Fisher <matt.fisher@fishworks.io>
+   Copyright 2022 Matthew Fisher <matt.fisher@fishworks.io>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
+      - uses: bacongobbler/azure-blob-storage-upload@main
         with:
           source_dir: _dist
           container_name: www
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: chabad360/hugo-actions@master
-      - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
+      - uses: bacongobbler/azure-blob-storage-upload@main
         with:
           source_dir: 'public'
           container_name: '$web'

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   icon: "box"
   color: "green"
 inputs:
+  cli_version:
+    description: "If set, specifies the version of the Azure CLI to install. Defaults to latest"
+    required: false
   connection_string:
     description: "The connection string for the storage account. Used if value is set. Either connection_string or sas_token must be supplied"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,4 +40,12 @@ if [ -z "$INPUT_SYNC" ]; then
   CONTAINER_NAME_FLAG="--container"
 fi
 
+CLI_VERSION=""
+if ! [ -z "$INPUT_CLI_VERSION" ]; then
+  CLI_VERSION="==${INPUT_CLI_VERSION}"
+fi
+
+# install the azure cli
+pip install azure-cli${CLI_VERSION}
+
 az storage blob ${VERB} ${CONNECTION_METHOD} --source ${INPUT_SOURCE_DIR} ${CONTAINER_NAME_FLAG} ${INPUT_CONTAINER_NAME} ${EXTRA_ARGS}


### PR DESCRIPTION
There's a slight performance hit as the CLI now has to be installed
during runtime. However, this change allows the user to change the CLI
version at-will, allowing them to pin to a specific version.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>